### PR TITLE
passing multipart configuration down from worker manager to worker

### DIFF
--- a/src/js/core/WorkerManager.js
+++ b/src/js/core/WorkerManager.js
@@ -68,7 +68,17 @@ class CurateWorkerManager {
     if (this.taskQueue.length > 0) {
       const task = this.taskQueue.shift();
       this.currentTasks.set(workerId, task);
-      worker.postMessage({ file: task.file, msg: "begin hash" });
+
+      // Get PydioApi values and pass them to worker
+      const multipartThreshold = PydioApi.getMultipartThreshold();
+      const multipartPartSize = PydioApi.getMultipartPartSize();
+
+      worker.postMessage({
+        file: task.file,
+        msg: "begin hash",
+        multipartThreshold,
+        multipartPartSize
+      });
     } else if (this.currentTasks.size === 0) {
       // No more tasks in queue and no running tasks - cleanup workers
       this.cleanupWorkers();


### PR DESCRIPTION
Fix checksum worker parameter passing and PydioApi method calls

  - Move PydioApi calls from worker to WorkerManager to fix worker context issues
  - Correct PydioApi.getMultipartPartSize() to getMultipartThreshold() for threshold check
  - Pass multipartThreshold and multipartPartSize as parameters to worker
  - Re-add incrementalMD5 implementation for single-file checksum calculation
  - Use proper multipartPartSize for calculateMultipartChecksum function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved file hashing performance and reliability for both small and large uploads.
  - More efficient handling of large files through size-aware multipart hashing.

- Refactor
  - Streamlined worker communication by passing size parameters directly.
  - Simplified hashing worker behavior and cleanup; reduced console noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->