### PR TITLE
Dev/new bundle versioning

### DIFF
--- a/.github/workflows/webpack-build.yml
+++ b/.github/workflows/webpack-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -11,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5 
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -20,18 +22,31 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          npm install  # Install dependencies
+        run: npm install
 
       - name: Build with Webpack
-        run: |
-          npm run build  # Run Webpack to create the build
+        run: npm run build
 
-      - name: Deploy to GitHub Pages (gh-pages)
+      - name: Deploy to latest
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
+          destination_dir: latest
+          keep_files: true
+          user_name: "github-actions"
+          user_email: "github-actions@github.com"
+
+      - name: Deploy versioned release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          destination_dir: ${{ github.ref_name }}
+          keep_files: true
           user_name: "github-actions"
           user_email: "github-actions@github.com"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const webpack = require("webpack");
-const fs = require("fs-extra");
 const packageJson = require("./package.json");
 const TerserPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -19,15 +18,9 @@ module.exports = (env, argv) => {
       },
     },
     output: {
-      // In development, output to dist root for easier dev server serving
-      // In production, output to versioned directory
-      filename: isProduction
-        ? `[name]_${packageJson.version}.js`
-        : `[name].js`,
+      filename: "[name].js",
       chunkFilename: "[name].[chunkhash].js",
-      path: isProduction
-        ? path.resolve(__dirname, "dist", packageJson.version)
-        : path.resolve(__dirname, "dist"),
+      path: path.resolve(__dirname, "dist"),
       globalObject: "this",
       clean: true,
     },
@@ -36,84 +29,22 @@ module.exports = (env, argv) => {
         "process.env.VERSION": JSON.stringify(packageJson.version),
       }),
 
-      // Copy replaywebpage and worker library files to dist
       new CopyWebpackPlugin({
         patterns: [
           {
             from: path.resolve(__dirname, "node_modules/replaywebpage/sw.js"),
-            to: path.resolve(__dirname, isProduction ? `dist/${packageJson.version}` : "dist", "replaywebpage-sw.js"),
+            to: path.resolve(__dirname, "dist/replaywebpage-sw.js"),
           },
           {
             from: path.resolve(__dirname, "node_modules/replaywebpage/ui.js"),
-            to: path.resolve(__dirname, isProduction ? `dist/${packageJson.version}` : "dist", "replaywebpage-ui.js"),
+            to: path.resolve(__dirname, "dist/replaywebpage-ui.js"),
           },
           {
             from: path.resolve(__dirname, "node_modules/spark-md5/spark-md5.js"),
-            to: path.resolve(__dirname, isProduction ? `dist/${packageJson.version}` : "dist", "spark-md5.js"),
+            to: path.resolve(__dirname, "dist/spark-md5.js"),
           },
         ],
       }),
-
-      // Only run the custom plugin in production mode
-      ...(isProduction ? [
-        new CopyWebpackPlugin({
-          patterns: [
-            {
-              from: path.resolve(__dirname, "node_modules/replaywebpage/sw.js"),
-              to: path.resolve(__dirname, "dist/@latest/replaywebpage-sw.js"),
-            },
-            {
-              from: path.resolve(__dirname, "node_modules/replaywebpage/ui.js"),
-              to: path.resolve(__dirname, "dist/@latest/replaywebpage-ui.js"),
-            },
-            {
-              from: path.resolve(__dirname, "node_modules/spark-md5/spark-md5.js"),
-              to: path.resolve(__dirname, "dist/@latest/spark-md5.js"),
-            },
-          ],
-        }),
-        {
-          apply(compiler) {
-            compiler.hooks.afterEmit.tapAsync(
-              "CopyLatestBuild",
-              (_, callback) => {
-                const versionDir = path.resolve(
-                  __dirname,
-                  "dist",
-                  packageJson.version
-                );
-                const latestDir = path.resolve(__dirname, "dist", "@latest");
-
-                // Make sure the @latest folder exists
-                fs.emptyDirSync(latestDir);
-
-                fs.readdir(versionDir, (err, files) => {
-                  if (err) {
-                    console.error("Error reading versioned files:", err);
-                    return callback();
-                  }
-
-                  const copyPromises = files.map(file => {
-                    const sourcePath = path.resolve(versionDir, file);
-                    const targetPath = path.resolve(
-                      latestDir,
-                      file.replace(`_${packageJson.version}.js`, ".js")
-                    );
-
-                    return fs.copy(sourcePath, targetPath).then(() => {
-                      console.log(`Successfully copied ${file} to @latest`);
-                    }).catch(copyErr => {
-                      console.error(`Error copying file to @latest: ${file}`, copyErr);
-                    });
-                  });
-
-                  Promise.all(copyPromises).then(() => callback()).catch(() => callback());
-                });
-              }
-            );
-          },
-        }
-      ] : []),
     ],
     module: {
       rules: [


### PR DESCRIPTION
Updated versioning procedure for the JS bundle. Now, the action builds the bundle to a versioned directory when a release tag is cut. It will also bundle the latest code on each commit to the latest directory. This means we proceed with continuously pushing enhancements and improvements to the bundle as we go, and then when we have a large set of functionality to go in and wish to lock some users to the stable version, we cut a new release for them. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build and deployment infrastructure. The release workflow now supports semantic versioning with version-tagged releases deploying to dedicated version directories for archive preservation, while main branch commits deploy to the latest destination. Build output structure has been simplified and consolidated into a unified directory configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->