### PR TITLE
fix(deps): override fast-xml-parser >=4.5.4 (critical)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,9 +4233,9 @@
       ]
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
       "funding": [
         {
           "type": "github",
@@ -4244,7 +4244,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "worker-loader": "^3.0.8"
+  },
+  "overrides": {
+    "fast-xml-parser": "^4.5.4"
   }
 }


### PR DESCRIPTION
Resolves the **critical** Dependabot alert: `fast-xml-parser` entity-encoding bypass via regex injection.

`fast-xml-parser` is a **transitive** dep via `@webrecorder/wabac` (`^4.4.1`), locked at the vulnerable **4.5.3**. Added an npm `overrides` pinning it to `^4.5.4` (resolved **4.5.6**); `^4.5.4` still satisfies wabac's `^4.4.1`.

Verified locally: `npm run build` (webpack 5.99.9) compiles with only the pre-existing asset-size warnings, no errors.

⚠️ **Merge note:** merging this to `main` triggers the build+deploy workflow that publishes `./dist` to the live `latest` channel (browser-injected into Cells). Build is verified locally; merge when ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency override configuration to ensure consistent package versions during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/penwern/curate-dev-js/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->