### PR TITLE
docs: document CI + test status

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,9 @@ npm run serve
 # Container deployment with docker
 npm run docker:up
 ```
+
+## Testing & CI
+
+CI runs **lint only** (ESLint + Prettier via penwern-ci, gate mode) and the production webpack build (deployed to `gh-pages` / `dist/@latest/`).
+
+There is **no automated test suite yet**. The web components are browser-coupled (they extend the Cells `window.Curate` runtime), so adding tests requires a `vitest` + `jsdom` harness — not yet set up. (When added, the repo can be onboarded to penwern-ci's `reusable-test.yml` with `language: js-vanilla`.)


### PR DESCRIPTION
Notes that CI is lint-only + webpack build, and that no test suite exists yet (browser-coupled components need vitest/jsdom before onboarding to reusable-test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README with a new "Testing & CI" section describing continuous integration behavior, including linting and production build deployment to gh-pages. Also notes that an automated test suite is not yet available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/penwern/curate-dev-js/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->