### PR TITLE
chore: set version to 1.2.0 (proper v1.x semver)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curate-js",
-  "version": "4.5.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curate-js",
-      "version": "4.5.0",
+      "version": "1.2.0",
       "dependencies": {
         "@iconify/iconify": "^3.1.1",
         "@lit-labs/virtualizer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curate-js",
-  "version": "4.5.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "webpack --mode production --config ./webpack.config.js",
     "serve": "npx webpack serve --mode development --config ./webpack.config.js",


### PR DESCRIPTION
Aligns `package.json`/`package-lock.json` to the proper independent v1.x version line introduced in #130, decoupling from the Cells release number (4.x) the field had been tracking. So the webpack-injected `process.env.VERSION` matches the `v1.2.0` git tag/release.

Next: tag `v1.2.0` off this merge → publishes `gh-pages/v1.2.0/`, then curate116 pins to it.