### PR TITLE
ci(webpack): build on PRs, Node 22, npm ci

### DIFF
--- a/.github/workflows/webpack-build.yml
+++ b/.github/workflows/webpack-build.yml
@@ -6,6 +6,13 @@ on:
       - main
     tags:
       - 'v*'
+  # Build (but do NOT deploy) on PRs so a broken build is caught before it reaches
+  # main and auto-publishes to the rolling gh-pages/latest/ bundle prod tracks. The
+  # deploy steps below are gated on refs/heads/main and refs/tags/v*, so on a
+  # pull_request event (github.ref = refs/pull/N/merge) neither fires.
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -18,11 +25,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"   # match NODE_VERSION in penwern-ci so build == lint runtime
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci   # reproducible install from package-lock.json (was: npm install)
 
       - name: Build with Webpack
         run: npm run build


### PR DESCRIPTION
From the CICD_AGENT_REPORT version-drift + PR-build items:
- **Build on PRs.** The webpack build ran only on push to main/tags, so build breaks reached `main` (and the rolling `gh-pages/latest/` bundle prod tracks) uncaught. Now also runs on `pull_request`; deploy steps stay gated on `refs/heads/main`/`refs/tags/v*` so PRs build but never publish.
- **Node 20 → 22**, matching `NODE_VERSION` in penwern-ci (build == lint runtime).
- **`npm install` → `npm ci`** for a reproducible lockfile-pinned install.

This PR's own run is the first build-on-PR check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD pipeline to trigger build verification on pull requests targeting main
* Upgraded Node.js runtime environment to version 22
* Enhanced dependency management for more reproducible and reliable builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->