### PR TITLE
fix: remove em dashes from user-facing copy

### DIFF
--- a/src/js/info-panel-cards/IngestionInfoCard.jsx
+++ b/src/js/info-panel-cards/IngestionInfoCard.jsx
@@ -9,7 +9,7 @@ const WARNING_EXPLANATIONS = {
   "match on text only; extension mismatch":
     "Format was identified from text content only (lower confidence) and the file extension doesn't match either.",
   "match on text only":
-    "Format identified from text content only — byte-level signatures were not matched. Confidence is lower than a signature-based match.",
+    "Format identified from text content only. Byte-level signatures were not matched, so confidence is lower than a signature-based match.",
   "filename mismatch": "The filename doesn't match the expected naming pattern for this format.",
 };
 

--- a/src/js/web-components/atom-config-readonly/atom-config-readonly.js
+++ b/src/js/web-components/atom-config-readonly/atom-config-readonly.js
@@ -106,7 +106,7 @@ class AtomConfigReadonly extends LitElement {
     }
     if (!this.configured) {
       return html`<div class="status">
-        AtoM is not yet configured for this site. Penwern manages this configuration — please
+        AtoM is not yet configured for this site. Penwern manages this configuration, so please
         contact support.
       </div>`;
     }


### PR DESCRIPTION
## What

Removes em dashes from the two strings in this bundle that render as prose to an end user.

| Location | Before | After |
|---|---|---|
| `atom-config-readonly.js` | `Penwern manages this configuration — please contact support.` | `Penwern manages this configuration, so please contact support.` |
| `IngestionInfoCard.jsx` | `...text content only — byte-level signatures were not matched.` | `...text content only. Byte-level signatures were not matched, so...` |

## Why

The AtoM string was spotted live on curate117, on the branch that renders when no AtoM credentials are configured. Em dashes are not used in Penwern copy, and this bundle tracks `latest` in production, so shipped strings are the highest-visibility place for one to sit unnoticed.

## Scope

Deliberately limited to prose that a user reads. Not touched in this PR:

- 34 dashboard export labels and xlsx sheet names in `dashboard.js` (`"CSV — Upload Records"`, `"Overview — File Types"`, and similar)
- 16 uses of a bare `"—"` as an empty-value placeholder, which is a design glyph rather than punctuation
- 16 developer-only occurrences in comments, one `console.warn`, and four thrown `Error` messages

## Verification

- `npx eslint src/` passes
- `npx prettier --list-different src/` returns the same 43 pre-existing files before and after this change, so nothing new was introduced. Both edited files are clean under prettier
- No behaviour change; string content only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved punctuation and phrasing in ingestion warning explanations.
  * Refined the wording of the site configuration message for clearer readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->