### PR TITLE
add new path to metadata fields to infopanel card consumers

### DIFF
--- a/src/js/info-panel-cards/IngestionInfoCard.jsx
+++ b/src/js/info-panel-cards/IngestionInfoCard.jsx
@@ -232,7 +232,7 @@ function IngestionInfoCard(props) {
   let sf = null;
   let sfMatch = null;
   try {
-    const sfRaw = meta.get("Siegfried");
+    const sfRaw = meta.get("usermeta-siegfried") ?? meta.get("Siegfried");
     if (sfRaw) {
       sf = typeof sfRaw === "string" ? JSON.parse(sfRaw) : sfRaw;
       sfMatch = sf?.files?.[0]?.matches?.[0] ?? null;
@@ -246,7 +246,7 @@ function IngestionInfoCard(props) {
   const mime = sfMatch?.mime || meta.get("mime") || null;
   const basisLabel = humaniseBasis(sfMatch?.basis ?? null);
   const warningExplanation = getWarningExplanation(sfMatch?.warning ?? null);
-  const premis = meta.get("Premis") || [];
+  const premis = meta.get("usermeta-premis-data") ?? meta.get("Premis") ?? [];
   const accession = premis.find((event) => event.event_type === "Accession");
   const accessioned = accession?.event_date_time
     ? new Date(accession.event_date_time).toLocaleDateString(undefined, {

--- a/src/js/info-panel-cards/PremisEventsCard.jsx
+++ b/src/js/info-panel-cards/PremisEventsCard.jsx
@@ -292,8 +292,7 @@ function PremisEventsCard(props) {
   }, []);
   useHeaderControls(markerRef, effectiveOpen, setOpen, "Preservation Events", pinState);
 
-  const raw =
-    node._metadata.get("usermeta-premis-data") ?? node._metadata.get("Premis") ?? [];
+  const raw = node._metadata.get("usermeta-premis-data") ?? node._metadata.get("Premis") ?? [];
   const events = processEvents(raw);
   const count = raw.length;
   const [visibleCount, setVisibleCount] = React.useState(() =>
@@ -409,8 +408,7 @@ Curate.infoPanel.registerCard({
   component: PremisEventsCard,
   mime: ["generic_file"],
   condition: (node) => {
-    const premis =
-      node?._metadata?.get("usermeta-premis-data") ?? node?._metadata?.get("Premis");
+    const premis = node?._metadata?.get("usermeta-premis-data") ?? node?._metadata?.get("Premis");
     return Array.isArray(premis) && premis.length > 0;
   },
   weight: 11,

--- a/src/js/info-panel-cards/PremisEventsCard.jsx
+++ b/src/js/info-panel-cards/PremisEventsCard.jsx
@@ -292,7 +292,8 @@ function PremisEventsCard(props) {
   }, []);
   useHeaderControls(markerRef, effectiveOpen, setOpen, "Preservation Events", pinState);
 
-  const raw = node._metadata.get("Premis") || [];
+  const raw =
+    node._metadata.get("usermeta-premis-data") ?? node._metadata.get("Premis") ?? [];
   const events = processEvents(raw);
   const count = raw.length;
   const [visibleCount, setVisibleCount] = React.useState(() =>
@@ -408,7 +409,8 @@ Curate.infoPanel.registerCard({
   component: PremisEventsCard,
   mime: ["generic_file"],
   condition: (node) => {
-    const premis = node?._metadata?.get("Premis");
+    const premis =
+      node?._metadata?.get("usermeta-premis-data") ?? node?._metadata?.get("Premis");
     return Array.isArray(premis) && premis.length > 0;
   },
   weight: 11,

--- a/src/js/info-panel-cards/SiegfriedCard.jsx
+++ b/src/js/info-panel-cards/SiegfriedCard.jsx
@@ -409,7 +409,7 @@ function SiegfriedCard(props) {
   useHeaderControls(markerRef, effectiveOpen, setOpen, "File Identification", pinState);
 
   const { node } = props;
-  const raw = node._metadata.get("Siegfried");
+  const raw = node._metadata.get("usermeta-siegfried") ?? node._metadata.get("Siegfried");
   if (!InfoPanelCard || !raw) return null;
 
   let sf;
@@ -519,6 +519,7 @@ Curate.infoPanel.registerCard({
   identifier: "curate-siegfried",
   component: SiegfriedCard,
   mime: ["generic_file"],
-  condition: (node) => !!node?._metadata?.get("Siegfried"),
+  condition: (node) =>
+    !!(node?._metadata?.get("usermeta-siegfried") ?? node?._metadata?.get("Siegfried")),
   weight: 2,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display of Siegfried metadata when available under either supported metadata label.
  - Improved display of PREMIS accession and event information across supported metadata formats.
  - PREMIS and Siegfried information cards now appear correctly when metadata is provided using either supported label.
  - PREMIS accession details now safely show no entries when no data is available.
  - Metadata cards now consistently recognize preferred values while preserving compatibility with existing formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->