### PR TITLE
fix: gate integrity tag on usermeta-premis-data, not internal Premis

### DIFF
--- a/src/js/core/UploadInterceptor/plugins/ChecksumValidation/ChecksumValidation.js
+++ b/src/js/core/UploadInterceptor/plugins/ChecksumValidation/ChecksumValidation.js
@@ -40,7 +40,7 @@ function waitForPremisAndApplyTag(node, filePath, integrityTag, retryCount = 0) 
   const retryDelay = 3000; // Delay in ms before retrying
 
   // Check if both required metadata exist on the node
-  const hasPremis = node.MetaStore && node.MetaStore.Premis;
+  const hasPremis = node.MetaStore && node.MetaStore["usermeta-premis-data"];
   const hasVirusScan = node.MetaStore && node.MetaStore["usermeta-virus-scan-first"];
 
   if (hasPremis && hasVirusScan) {
@@ -50,7 +50,7 @@ function waitForPremisAndApplyTag(node, filePath, integrityTag, retryCount = 0) 
   } else if (retryCount < maxRetries) {
     // Required metadata not yet available, retry after delay
     const missing = [];
-    if (!hasPremis) missing.push("Premis");
+    if (!hasPremis) missing.push("premis");
     if (!hasVirusScan) missing.push("virus-scan");
     console.log(
       `Waiting for metadata (${missing.join(", ")}) on ${filePath}. Retrying (${


### PR DESCRIPTION
## Problem

`ChecksumValidation` defers writing the `usermeta-file-integrity` tag until PREMIS and virus-scan metadata are present on the node. The PREMIS half of that guard reads the **retired internal** namespace:

```js
const hasPremis = node.MetaStore && node.MetaStore.Premis;
```

The fleet-wide migration from the internal `Premis` store to `usermeta-premis-data` completed on 2026-08-14 with uob-prod, the last host. No host writes `MetaStore.Premis` any more, so `hasPremis` is permanently false.

## Effect

Not a hard failure, but degraded on every host: each upload now burns all 10 retries at 3s (**~30 seconds**), logs `Max retries reached waiting for required metadata`, and then applies the tag anyway via the fallback branch. Prod tracks `latest`, so this is live fleet-wide.

## Fix

Read `usermeta-premis-data`, which is the namespace the curation flow now writes. The virus-scan half of the guard already read a `usermeta-` key and is unchanged.

## Known limitation, not addressed here

The retry loop recurses with the same `node` object and never re-fetches `/a/tree/stats`, so the wait can only ever succeed when the metadata was already present at the first stat. This fix restores that case; making the wait genuinely poll would be a separate change.

## Verification

- `npx prettier --check` clean
- `npx eslint` clean
- `npm run build` succeeds

Part of the post-migration cleanup of internal Premis/Siegfried references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PREMIS metadata detection to recognize the current metadata key.
  * Improved retry messages by consistently displaying “premis” in lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->